### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To try it all out do this:
 $ go get -u github.com/philips/grpc-gateway-example
 $ grpc-gateway-example serve
 $ grpc-gateway-example echo "my first rpc echo"
-$ curl -X POST -k https://localhost:10000/v1/example/echo -H "Content-Type: text/plain" -d '{"value": "foo"}'
+$ curl -X POST -k https://localhost:10000/v1/echo -H "Content-Type: text/plain" -d '{"value": "foo"}'
 {"value":"my REST echo"}
 ```
 


### PR DESCRIPTION
The http handler does not serve subpath of example.

```
➜  ~ curl -X POST -k https://localhost:10000/v1/example/echo -H "Content-Type: text/plain" -d '{"value": "foo"}'
Not Found
➜  ~ curl -X POST -k https://localhost:10000/v1/echo -H "Content-Type: text/plain" -d '{"value": "foo"}'
{"value":"foo"}%
```