### PR TITLE
server.go: remove unnecessary http2 configuration

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -116,8 +116,6 @@ func serve() {
 		},
 	}
 
-	http2.ConfigureServer(srv, nil)
-
 	fmt.Printf("grpc on port: %d\n", port)
 	err = srv.Serve(tls.NewListener(conn, srv.TLSConfig))
 


### PR DESCRIPTION
we do not need this sincd go 1.6.