### PR TITLE
update gengo usage to grpc-ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ $ curl -X POST -k https://localhost:10000/v1/echo -H "Content-Type: text/plain" 
 Huge thanks to the hard work people have put into the [Go gRPC bindings][gogrpc] and [gRPC to JSON Gateway][grpcgateway]
 
 [gogrpc]: https://github.com/grpc/grpc-go
-[grpcgateway]: https://github.com/gengo/grpc-gateway
+[grpcgateway]: https://github.com/grpc-ecosystem/grpc-gateway

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/philips/grpc-gateway-example/pkg/ui/data/swagger"
 
-	"github.com/gengo/grpc-gateway/runtime"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/philips/go-bindata-assetfs"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"

--- a/echopb/Makefile
+++ b/echopb/Makefile
@@ -1,17 +1,17 @@
 all:
 	protoc -I/usr/local/include -I. \
 		-I${GOPATH}/src \
-		-I${GOPATH}/src/github.com/gengo/grpc-gateway/third_party/googleapis \
-		--go_out=Mgoogle/api/annotations.proto=github.com/gengo/grpc-gateway/third_party/googleapis/google/api,plugins=grpc:. \
+		-I${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
+		--go_out=Mgoogle/api/annotations.proto=github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api,plugins=grpc:. \
 		service.proto
 	protoc -I/usr/local/include -I. \
 		-I${GOPATH}/src \
-		-I${GOPATH}/src/github.com/gengo/grpc-gateway/third_party/googleapis \
+		-I${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
 		--grpc-gateway_out=logtostderr=true:. \
 		service.proto
 	protoc -I/usr/local/include -I. \
 		-I${GOPATH}/src \
-		-I${GOPATH}/src/github.com/gengo/grpc-gateway/third_party/googleapis \
+		-I${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
 		--swagger_out=logtostderr=true:. \
 		service.proto
 	go generate .

--- a/echopb/service.pb.go
+++ b/echopb/service.pb.go
@@ -16,7 +16,7 @@ package echopb
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gengo/grpc-gateway/third_party/googleapis/google/api"
+import _ "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api"
 
 import (
 	context "golang.org/x/net/context"
@@ -53,7 +53,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion2
+const _ = grpc.SupportPackageIsVersion3
 
 // Client API for EchoService service
 
@@ -115,8 +115,11 @@ var _EchoService_serviceDesc = grpc.ServiceDesc{
 			Handler:    _EchoService_Echo_Handler,
 		},
 	},
-	Streams: []grpc.StreamDesc{},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: fileDescriptor0,
 }
+
+func init() { proto.RegisterFile("service.proto", fileDescriptor0) }
 
 var fileDescriptor0 = []byte{
 	// 154 bytes of a gzipped FileDescriptorProto

--- a/echopb/service.pb.gw.go
+++ b/echopb/service.pb.gw.go
@@ -13,9 +13,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gengo/grpc-gateway/runtime"
-	"github.com/gengo/grpc-gateway/utilities"
 	"github.com/golang/protobuf/proto"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/grpc-ecosystem/grpc-gateway/utilities"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -83,7 +83,11 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 			}(ctx.Done(), cn.CloseNotify())
 		}
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		resp, md, err := request_EchoService_Echo_0(runtime.AnnotateContext(ctx, req), inboundMarshaler, client, req, pathParams)
+		rctx, err := runtime.AnnotateContext(ctx, req)
+		if err != nil {
+			runtime.HTTPError(ctx, outboundMarshaler, w, req, err)
+		}
+		resp, md, err := request_EchoService_Echo_0(rctx, inboundMarshaler, client, req, pathParams)
 		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, outboundMarshaler, w, req, err)

--- a/echopb/service.swagger.json
+++ b/echopb/service.swagger.json
@@ -20,7 +20,7 @@
         "operationId": "Echo",
         "responses": {
           "200": {
-            "description": "Description",
+            "description": "",
             "schema": {
               "$ref": "#/definitions/echopbEchoMessage"
             }

--- a/echopb/swagger.pb.go
+++ b/echopb/swagger.pb.go
@@ -4,8 +4,8 @@ const (
 swagger = `{
   "swagger": "2.0",
   "info": {
-    "version": "",
-    "title": ""
+    "title": "service.proto",
+    "version": "version not set"
   },
   "schemes": [
     "http",
@@ -20,11 +20,10 @@ swagger = `{
   "paths": {
     "/v1/echo": {
       "post": {
-        "summary": "EchoService.Echo",
         "operationId": "Echo",
         "responses": {
-          "default": {
-            "description": "Description",
+          "200": {
+            "description": "",
             "schema": {
               "$ref": "#/definitions/echopbEchoMessage"
             }


### PR DESCRIPTION
`github.com/gengo/grpc-gateway` now redirects to `github.com/grpc-ecosystem/grpc-gateway`, which it appears is disliked by golang and results in the following when running `go get -u github.com/philips/grpc-gateway-example`:
```
package github.com/philips/grpc-gateway-example
	imports github.com/philips/grpc-gateway-example/cmd
	imports github.com/gengo/grpc-gateway/runtime
	imports github.com/grpc-ecosystem/grpc-gateway/runtime/internal: use of internal package not allowed
```
Usage of gengo is updated throughout the repo, and I generated new protobufs with the edited makefile and protoc 3.0.0-beta-4. 